### PR TITLE
0608 1433

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -27,9 +27,9 @@ connect={"cseip":host,"cseport":7579,"csename":csename,"cseid":csename,"mqttip":
 
 # AC X,Y,Z can't coexist in current conf
 make_ae(F'ae.{bridge}-AC_S1M_01_X', csename, install, connect)
-#make_ae(F'ae.{bridge}-DI_S1M_01_X', csename, install, connect)
-#make_ae(F'ae.{bridge}-TP_S1M_01_X', csename, install, connect)
-#make_ae(F'ae.{bridge}-TI_S1M_01_X', csename, install, connect)
+make_ae(F'ae.{bridge}-DI_S1M_01_X', csename, install, connect)
+make_ae(F'ae.{bridge}-TP_S1M_01_X', csename, install, connect)
+make_ae(F'ae.{bridge}-TI_S1M_01_X', csename, install, connect)
 
 root='/home/pi/GB'
 for aename in ae:

--- a/savedData.py
+++ b/savedData.py
@@ -15,6 +15,9 @@ from threading import Timer, Thread
 import create
 from conf import ae, root, memory
 
+import zipfile
+from os.path import basename
+
 def sensor_type(aename):
     return aename.split('-')[1][0:2]
 
@@ -170,12 +173,20 @@ def savedJson(aename,raw_json, t1_start, t1_msg):
         port = ae[aename]['config']['connect']['uploadport']
         url = F"http://{host}:{port}/upload"
         print(f'{aename} upload url= {url} {file_name}')
+        
+        # 파일 압축 실행
+        zip_file_name = F"{file_name[:len(file_name)-4]}.zip"
+        zip_file = zipfile.ZipFile(zip_file_name, "w")
+        zip_file.write(file_name, basename(file_name), compress_type=zipfile.ZIP_DEFLATED)
+        zip_file.close()
+        print(f"file compression has completed > {zip_file_name}")
+
         try:
-            r = requests.post(url, data = {"keyValue1":12345}, files = {"attachment":open(file_name, "rb")})
+            r = requests.post(url, data = {"keyValue1":12345}, files = {"attachment":open(zip_file_name, "rb")})
             print(f'TIMER: {aename} result= {r.text}')
         except:
-            print(f'TIMER: fail-to-upload {aename} file={file_name}')
-
+            print(f'TIMER: fail-to-upload {aename} file={zip_file_name}')
+    
     #upload(aename, f'{save_path}/{file_name}.bin')
     print(f'TIMER: upload +3s')
     Timer(3, upload).start()


### PR DESCRIPTION
- data->dtrigger의 파라메터 data를 쪼개지 않고 하나의 파라메터 array에 넣는 것으로 변경하였습니다. 건기연에서 연락을 받았는데, 파라메터명이 달라서 table에 데이터가 하나도 안 뜬다... 이런식으로 말씀하시면서 요청하셔서요. 스마트제어계측에서 테스트했을때에는 하나의 파라메터에 데이터 전부 넣어도 누락되는 것이 없었다고 합니다.
- settime, setconnect 명령어를 보내는 경우 갱신한 파라메터만 cin에 갱신되는 현상을 수정하였습니다. 예를들어 uploadport=80 만 작성하여 setconnect 명령어를 보내면, config->connect cin에도 uploadport=80만올라가는 식으로 작동하고 있었습니다. for문을 이용해 key별로 갱신하도록 수정하였습니다.
- setmeasure 명령어 입력 시, st1min, st1max, samplerate를 올바른 파라메터로 인식하지 못하는 현상을 발견해 수정하였습니다. 혹시 몰라 rawperiod도 변경 가능하도록 만들어두었습니다. 이건 조금 다른 이야기지만 set명령어들은 추후 입력받은 파라메터들의 자료형을 검사하는 코드를 추가하는 게 좋을 것 같습니다.
-