### PR TITLE
DI data align, TP offset bug fix

### DIFF
--- a/Client_Data_Saving.py
+++ b/Client_Data_Saving.py
@@ -1303,6 +1303,7 @@ def a_dinfo():
         r+=f'<br>'
         r+=f'Version : {VERSION}'
         print(r)
+        break
         
     r = f"<html><head><meta http-equiv=refresh content=3></head><body>{r}</body>"
     #r = f"<html><body>{r}</body>"

--- a/Server_Data_Sending.py
+++ b/Server_Data_Sending.py
@@ -344,7 +344,7 @@ def data_receiving():
             degreeX = deg_conversion(rcv4[0:2]) + Offset['TI'] 
             degreeY = deg_conversion(rcv4[2:4]) + Offset['TI'] 
             degreeZ = deg_conversion(rcv4[4:6]) + Offset['TI'] 
-            Temperature = tem_conversion(rcv4[6:8]) + Offset['DP']
+            Temperature = tem_conversion(rcv4[6:8]) + Offset['TP']
             # 식을 dis_conversion으로 변경하여 해결하였음
             Displacement_ch4 = dis_conversion(rcv4[8:12]) + Offset['DI']
             Displacement_ch5 = dis_conversion(rcv4[12:]) + Offset['DI']

--- a/Server_Data_Sending.py
+++ b/Server_Data_Sending.py
@@ -344,21 +344,22 @@ def data_receiving():
             degreeX = deg_conversion(rcv4[0:2]) + Offset['TI'] 
             degreeY = deg_conversion(rcv4[2:4]) + Offset['TI'] 
             degreeZ = deg_conversion(rcv4[4:6]) + Offset['TI'] 
-            Temperature = tem_conversion(rcv4[6:8]) + Offset['DI']
+            Temperature = tem_conversion(rcv4[6:8]) + Offset['DP']
             # 식을 dis_conversion으로 변경하여 해결하였음
             Displacement_ch4 = dis_conversion(rcv4[8:12]) + Offset['DI']
             Displacement_ch5 = dis_conversion(rcv4[12:]) + Offset['DI']
         else: 
             #print("s:"+ "0x40")
-            rcv4 = spi.xfer2([0x40]*22) # follow up action
+            rcv4 = spi.xfer2([0x40]*24) # follow up action
             #print(rcv4)
             degreeX = deg_conversion(rcv4[0:4]) + Offset['TI'] 
             degreeY = deg_conversion(rcv4[4:8]) + Offset['TI'] 
             degreeZ = deg_conversion(rcv4[8:12]) + Offset['TI'] 
-            Temperature = tem_conversion(rcv4[12:14]) + Offset['DI']
+            Temperature = tem_conversion(rcv4[12:14]) + Offset['TP']
+            # 14~15 is skipped by mcu compiler!
             # 식을 dis_conversion으로 변경하여 해결하였음
-            Displacement_ch4 = dis_conversion(rcv4[14:18]) + Offset['DI']
-            Displacement_ch5 = dis_conversion(rcv4[18:]) + Offset['DI']
+            Displacement_ch4 = dis_conversion(rcv4[16:20]) + Offset['DI']
+            Displacement_ch5 = dis_conversion(rcv4[20:]) + Offset['DI']
 
         json_data["TI"] = {"x":degreeX, "y":degreeY, "z":degreeZ}
         json_data["TP"] = Temperature


### PR DESCRIPTION
- align byte position of DI after increaing to 4 bytes. Total is increaset from 6 to 12. A temperate is 2 bytes. So, mcu compilter added 2bytes before DI data for alignmnet. RPI server should consider this.
- change offset bug for TP
- add break at the end of  loop in a_dinfo() 