### PR TITLE
0816 1727

### DIFF
--- a/Client_Data_Saving.py
+++ b/Client_Data_Saving.py
@@ -331,6 +331,10 @@ def do_user_command(aename, jcmd):
             for x in k1: m += f" {x}"
             warn_state(m)
             return
+        if "mode" in jcmd:
+            if not jcmd["mode"] in {1, 2, 3, 4}: # mode는 오로지 숫자 1, 2, 3, 4만을 입력으로 받는다 #테스트요망
+                warn_state("ctrigger->mode must be 1 or 2 or 3 or 4")
+                return
 
         #cmeasure 명령어의 키워드 유효성 검사
         k1=set(jcmd) - {'sensitivity','offset','measureperiod','stateperiod', 'rawperiod', 'usefft', 'st1max', 'st1min', 'st2max', 'st2min', 'st3max', 'st3min', 'st4max', 'st4min', 'st5max', 'st5min', 'st6max', 'st6min', 'st7max', 'st7min', 'st8max', 'st8min', 'st9max', 'st9min', 'st10max', 'st10min','formula', 'samplerate'}
@@ -550,18 +554,20 @@ def mqtt_sending(aename, data):
     global mqttc, mqttc_failed_at
     if mqttc=="" and (datetime.now() - mqttc_failed_at).total_seconds()>600:
         mqttc = connect_mqtt()
-    else:
-        print('mqtt_sending: not conneccted. skip sending...')
-        return
+        #연결을 시도했음에도 불구하고 연결이 되지 않았다면 mqtt 전송을 스킵 #테스트요망
+        if mqttc=="":
+            print('mqtt_sending: not conneccted. skip sending...')
+            return
 
     if mqttc=="":
         print('***** failed to connect mqtt again. will try in 10 minutes')
         mqttc_failed_at=datetime.now()
         return
+    '''
     else:
         mqttc.loop_start()
         print("mqtt 재연결에 성공했습니다.")
-
+    '''
     now = datetime.now()
     test_list = list()
     if type(data) == type(test_list):
@@ -821,7 +827,7 @@ def do_capture():
                         trigger_data = ac[acc_axis(aename)]
                         break
                     elif ctrigger['mode'] == 3:
-                        if ac[acc_axis(aename)] > ctrigger['st1high'] and ac[acc_axis(aename)] < ctrigger['st1low']:
+                        if ac[acc_axis(aename)] > ctrigger['st1high'] or ac[acc_axis(aename)] < ctrigger['st1low']:
                             trigger_data = ac[acc_axis(aename)]
                             break
                     elif ctrigger['mode'] == 4:

--- a/actuate_no_cmd.py
+++ b/actuate_no_cmd.py
@@ -34,11 +34,12 @@ def actuate(aename, cmd):
 
 
 config_json = {
-  "cmd":"setmeasure",
-  "measureperiod":600
+  "cmd":"settrigger",
+  "use":"N"
+
 }
 
-actuate("ae.11001100-TI_S1M_01_X", config_json)
+actuate("ae.11001100-AC_S1M_01_X", config_json)
 
 # 이하로는 실제 현장에 설치된 테스트 센서의 AE 리스트 #
 ####################################################

--- a/conf.py
+++ b/conf.py
@@ -18,8 +18,8 @@ from default import make_ae, ae, TOPIC_list, supported_sensors
 #bridge = 80061056 #placecode 설정을 위해 변수로 재설정
 #bridge = 42345141 #placecode 설정을 위해 변수로 재설정
 #bridge = 32345141 #규약 테스트용
-bridge = 80062057 #placecode 설정을 위해 변수로 재설정
-#bridge = 11001100 # 개인 테스트용
+#bridge = 80062057 #placecode 설정을 위해 변수로 재설정
+bridge = 11001100 # 개인 테스트용
 #bridge = 99998877
 
 install= {"date":"2022-04-25","place":"금남2교(하)","placecode":F"{bridge}","location":"6.7m(P2~P3)","section":"최우측 거더","latitude":"37.657248","longitude":"127.359962","aetype":"D"}
@@ -27,10 +27,10 @@ install= {"date":"2022-04-25","place":"금남2교(하)","placecode":F"{bridge}",
 connect={"cseip":host,"cseport":7579,"csename":csename,"cseid":csename,"mqttip":host,"mqttport":port,"uploadip":uploadhost,"uploadport":uploadport}
 
 # AC X,Y,Z can't coexist in current conf
-make_ae(F'ae.{bridge}-AC_S1M_01_Y', csename, install, connect)
-ae[F'ae.{bridge}-AC_S1M_01_Y']['local']['axis']='z'
-#make_ae(F'ae.{bridge}-AC_S1M_02_Y', csename, install, connect)
-#make_ae(F'ae.{bridge}-AC_S1M_03_Z', csename, install, connect)
+make_ae(F'ae.{bridge}-AC_S1M_01_X', csename, install, connect)
+#ae[F'ae.{bridge}-AC_S1M_01_Y']['local']['axis']='z'
+#make_ae(F'ae.{bridge}-AC_S1M_01_Y', csename, install, connect)
+#make_ae(F'ae.{bridge}-AC_S1M_01_Z', csename, install, connect)
 #make_ae(F'ae.{bridge}-DS_S1M_01_X', csename, install, connect)
 #make_ae(F'ae.{bridge}-DS_S1M_01_Y', csename, install, connect)
 #make_ae(F'ae.{bridge}-DS_S1M_01_Z', csename, install, connect)
@@ -38,9 +38,9 @@ ae[F'ae.{bridge}-AC_S1M_01_Y']['local']['axis']='z'
 #make_ae(F'ae.{bridge}-DI_S1M_01_Y', csename, install, connect)
 #make_ae(F'ae.{bridge}-TP_S1M_01_X', csename, install, connect)
 #make_ae(F'ae.{bridge}-TI_S1M_01_X', csename, install, connect)
-#make_ae(F'ae.{bridge}-TI_S1M_01_Y', csename, install, connect)
+make_ae(F'ae.{bridge}-TI_S1M_01_Y', csename, install, connect)
 #make_ae(F'ae.{bridge}-TI_S1M_01_Z', csename, install, connect)
-#make_ae(F'ae.{bridge}-CM_S1M_01_X', csename, install, connect)
+make_ae(F'ae.{bridge}-CM_S1M_01_X', csename, install, connect)
 
 root='/home/pi/GB'
 for aename in ae:


### PR DESCRIPTION
- mqtt가 정상적으로 연결되어 있음에도 realstart 명령어 전송 시 실시간 데이터를 전송하지 않던 현상 수정
- mqtt쪽 수정으로 인해 10분 후 연결 재시도가 작동하지 않을 수 있음. 추후 확인 예정...
- config->ctrigger의 mode를 settrigger를 통해 설정할 때 1, 2, 3, 4 이외의 숫자가 입력되면 오류로 처리하도록 수정