### PR TITLE
0927 1034

### DIFF
--- a/actuate_no_cmd.py
+++ b/actuate_no_cmd.py
@@ -33,18 +33,20 @@ def actuate(aename, cmd):
     print(url, json.dumps(r.json()))
 
 config_json = {
-    "cmd":"reqstate"
+    "cmd":"fwupdate",
+    "protocol":"HTTP",
+    "ip":host,
+    "port":2883,
+    "path":"/fwupdate/20220923_105943.BIN"
 }
 '''
     "cmd":"fwupdate",
     "protocol":"HTTP",
     "ip":host,
     "port":2883,
-    "path":"/fwupdate/20220922_133458.BIN"
+    "path":"/fwupdate/20220923_105943.BIN"
 
 '''
-
-actuate("ae.T0115b-AC_S1M_01_X", config_json)
 
 #actuate("ae.11001100-AC_S1M_01_X", config_json)
 
@@ -54,23 +56,24 @@ actuate("ae.T0115b-AC_S1M_01_X", config_json)
 ## 테스트 센서 1 : 태리IC(상)/(하) ##
 
 #1 : 상행선 가속도
-#actuate("ae.025175-AC_S1Q2_01_Z", config_json)
+actuate("ae.025175-AC_S1Q2_01_Z", config_json)
 
 #2 : 상행선 가속도 변형률 온도
-#actuate("ae.025175-AC_S1Q2_02_Z", config_json)
+actuate("ae.025175-AC_S1Q2_02_Z", config_json)
 #actuate("ae.025175-DS_S1Q0_01_X", config_json)
 #actuate("ae.025175-TP_S1Q2_01", config_json)
 
 #3 : 상행선 경사 카메라 변위
 #actuate("ae.025175-DI_S1Q0_01_X", config_json)
 #actuate("ae.025175-CM_A1_01_X", config_json)
-#actuate("ae.025175-TI_A1_01_XY", config_json)
+#actuate("ae.025175-TI_A1_01_X", config_json)
+#actuate("ae.025175-TI_A1_01_Y", config_json)
 
 #4 : 하행선 가속도
-#actuate("ae.025176-AC_S1Q2_02_Z", config_json)
+actuate("ae.025176-AC_S1Q2_02_Z", config_json)
 
 #5 : 하행선 가속도 변형률 온도
-#actuate("ae.025176-TP_S1Q2_01", config_json)
+actuate("ae.025176-TP_S1Q2_01", config_json)
 #actuate("ae.025176-AC_S1Q2_01_Z", config_json)
 #actuate("ae.025176-DS_S1Q2_01_X", config_json)
 

--- a/camera.py
+++ b/camera.py
@@ -12,13 +12,8 @@ import numpy as np
 import requests
 from threading import Timer, Thread
 
-import zipfile
-from os.path import basename
-
-import create
 from conf import ae, root
 
-import zipfile
 from os.path import basename
 
 def sensor_type(aename):

--- a/default.py
+++ b/default.py
@@ -110,7 +110,7 @@ def make_ae(aename, csename, install, config_connect):
         ae[aename]['data']['dtrigger'].update(data_dtrigger)
         ae[aename]['data']['fft'].update(data_fft)
         ae[aename]['data']['dmeasure'].update(data_dmeasure)
-    ae[aename]['local']={'printtick':'N', 'realstart':'N', 'name':aename, 'upTime':"", 'serial': getserial(), 'mqtt':True}
+    ae[aename]['local']={'printtick':'N', 'realstart':'N', 'name':aename, 'upTime':"", 'serial': getserial(), 'mqtt':True, 'teststart':'N'}
     TOPIC_list[aename]=F'/{csename}/{aename}/realtime'
 
 def getserial():


### PR DESCRIPTION
1분간의 데이터(정적의 경우 60개, 동적의 경우 6000개)를 수시로 저장하는 기능인 'teststart' 추가
- 동작여부는 ae[aename]['local']의 key-value로서 추가되어있음. 기본값은 'N'. mqtt 명령어를 통해 'teststart'를 보내면 1분 데이터 저장을 시작하며, 'teststop'을 보내면 1분 데이터 저장을 종료한다. 
- 저장되는 데이터의 파일명과 파일형식은 기존 raw data와 동일. 단 raw data와는 다른 폴더에 저장(test_data/(aename))