### PR TITLE
221031

### DIFF
--- a/Client_Data_Saving.py
+++ b/Client_Data_Saving.py
@@ -858,6 +858,11 @@ def do_capture():
     global counter
     if counter<180:
         print(f"{counter} boardTime@capture= boardTime= {boardTime} rpiTime= {rpiTime} {(boardTime-rpiTime).total_seconds():.1f}s")
+        if (boardTime-rpiTime).total_seconds() <= - 50 :
+            print("COUNTER ERROR : too much gap between boardTime and rpiTime")
+            print("restart system...")
+            os.system("pm2 restart all")
+            sys.exit(1)
     if counter==180:
         print(f"print per-second-logs for first 3 minutes")
     counter+=1
@@ -1470,7 +1475,12 @@ def a_data():
 
     r0=f"<H3>{aename}</H3>"
 
-    mymemory = memory[aename]
+    try:
+        mymemory = memory[aename]
+    except:
+        r = "key error"
+        return r
+
     keys = sorted(mymemory['file'].keys())
     X=[]
     Y=[]

--- a/Client_Data_Saving.py
+++ b/Client_Data_Saving.py
@@ -858,11 +858,10 @@ def do_capture():
     global counter
     if counter<180:
         print(f"{counter} boardTime@capture= boardTime= {boardTime} rpiTime= {rpiTime} {(boardTime-rpiTime).total_seconds():.1f}s")
-        if (boardTime-rpiTime).total_seconds() <= - 50 :
+        if (boardTime-rpiTime).total_seconds() <= -50 or (boardTime-rpiTime).total_seconds() >= 50 : # 두 Time이 
             print("COUNTER ERROR : too much gap between boardTime and rpiTime")
             print("restart system...")
             os.system("pm2 restart all")
-            sys.exit(1)
     if counter==180:
         print(f"print per-second-logs for first 3 minutes")
     counter+=1

--- a/actuate_no_cmd.py
+++ b/actuate_no_cmd.py
@@ -33,7 +33,7 @@ def actuate(aename, cmd):
     print(url, json.dumps(r.json()))
 
 config_json = {
-    "cmd":"realstart"
+    "cmd":"autossh"
 }
 '''
     "cmd":"fwupdate",
@@ -43,9 +43,9 @@ config_json = {
     "path":"/fwupdate/20220923_105943.BIN"
 
 '''
-actuate("ae.T0138b-TI_S1M_01_X", config_json)
-actuate("ae.T0138b-TI_S1M_01_Y", config_json)
-actuate("ae.T0138b-TI_S1M_01_Z", config_json)
+#actuate("ae.T0262b-AC_S1M_01_X", config_json)
+#actuate("ae.T0199b-TI_S1M_01_Y", config_json)
+#actuate("ae.T0257b-TI_S1M_01_Z", config_json)
 #actuate("ae.T0250b-AC_S1M_01_X", config_json)
 #actuate("ae.T0216b-AC_S1M_01_X", config_json)
 #actuate("ae.002520-AC_S2Q2_02_Z", config_json)


### PR DESCRIPTION
- boardTime과 rpiTime이 50초 이상 차이나는 경우 pm2 restart하도록 변경
- GB web에서 데이터를 열람할 때 key를 틀린 경우 발생하는 에러에 예외 처리를 추가