### PR TITLE
1104 1050

### DIFF
--- a/actuate_no_cmd.py
+++ b/actuate_no_cmd.py
@@ -40,11 +40,11 @@ config_json = {
     "protocol":"HTTP",
     "ip":host,
     "port":2883,
-    "path":"/fwupdate/20220923_105943.BIN"
+    "path":"/fwupdate/20221028_151642.BIN"
 
 '''
-#actuate("ae.T0262b-AC_S1M_01_X", config_json)
-#actuate("ae.T0199b-TI_S1M_01_Y", config_json)
+actuate("ae.T0276a-TI_S1M_01_X", config_json)
+actuate("ae.T0252b-TI_S1M_01_X", config_json)
 #actuate("ae.T0257b-TI_S1M_01_Z", config_json)
 #actuate("ae.T0250b-AC_S1M_01_X", config_json)
 #actuate("ae.T0216b-AC_S1M_01_X", config_json)

--- a/conf.py
+++ b/conf.py
@@ -22,7 +22,7 @@ install= {"date":"2022-04-25","place":"금남2교(하)","placecode":F"{bridge}",
 #connect={"cseip":host,"cseport":7579,"csename":csename,"cseid":csename,"mqttip":host,"mqttport":port,"uploadip":uploadhost,"uploadport":uploadport}
 connect={"cseip":host,"cseport":7579,"csename":csename,"cseid":csename,"mqttip":host,"mqttport":port,"uploadip":uploadhost,"uploadport":uploadport}
 
-#make_ae(F'ae.{bridge}-AC_S1M_01_X', csename, install, connect)
+make_ae(F'ae.{bridge}-AC_S1M_01_X', csename, install, connect)
 #ae[F'ae.{bridge}-AC_S1M_01_Y']['local']['axis']='z'
 #make_ae(F'ae.{bridge}-AC_S1M_01_Y', csename, install, connect)
 #make_ae(F'ae.{bridge}-AC_S1M_01_Z', csename, install, connect)
@@ -35,10 +35,10 @@ connect={"cseip":host,"cseport":7579,"csename":csename,"cseid":csename,"mqttip":
 #make_ae(F'ae.{bridge}-TP_S1M_01_X', csename, install, connect)
 
 make_ae(F'ae.{bridge}-TI_S1M_01_X', csename, install, connect)
-make_ae(F'ae.{bridge}-TI_S1M_01_Y', csename, install, connect)
-make_ae(F'ae.{bridge}-TI_S1M_01_Z', csename, install, connect)
-ae[F'ae.{bridge}-TI_S1M_01_X']['local']['axis']='z'
-ae[F'ae.{bridge}-TI_S1M_01_Z']['local']['axis']='-x'
+#make_ae(F'ae.{bridge}-TI_S1M_01_Y', csename, install, connect)
+#make_ae(F'ae.{bridge}-TI_S1M_01_Z', csename, install, connect)
+#ae[F'ae.{bridge}-TI_S1M_01_X']['local']['axis']='z'
+#ae[F'ae.{bridge}-TI_S1M_01_Z']['local']['axis']='-x'
 
 #make_ae(F'ae.{bridge}-CM_S1M_01_X', csename, install, connect)
 

--- a/default.py
+++ b/default.py
@@ -28,10 +28,7 @@ config_cmeasure["CM"]={'measurestate':'measuring'} # CM은 cmeasure의 일부 �
 config_cmeasure["IF"]={'measurestate':'stopped'} # IF 자체는 측정을 시행하지 않음
 
 #                                     sec 3600          min 60           min 60
-cmeasure2={'offset':0,'measureperiod':3600,'stateperiod':60,'rawperiod':60,
-        'st1min':2.1, 'st1max':2.6, 'st2min':3.01, 'st2max':4.01, 'st3min':5.01, 'st3max':6.01, 'st4min':7.01, 'st4max':8.01,
-        'st5min':9.01, 'st5max':10.01, 'st6min':11.01, 'st6max':12.01, 'st7min':13.01, 'st7max':14.01, 'st8min':15.01, 'st8max':16.01,
-        'st9min':17.01, 'st9max':18.01, 'st10min':19.01, 'st10max':20.01,'formula':'센서값*Factor+Offset'}
+cmeasure2={'offset':0,'measureperiod':3600,'stateperiod':60,'rawperiod':60, 'st1min':2.1, 'st1max':2.6, 'formula':'지원하지 않음'}
 config_cmeasure['AC'].update(cmeasure2)  #deep copy
 config_cmeasure['DS'].update(cmeasure2)  #deep copy
 config_cmeasure['DI'].update(cmeasure2)  #deep copy


### PR DESCRIPTION
oneM2M 규약 테스트 결과에 따라 코드 수정
- ctrigger의 상한/하한값이 mode에 따라 파라메터를 추가, 삭제하도록 수정
- 따라서, settrigger 설정시 mode에 걸맞는 파라메터가 없으면 ctrigger를 변경하지 않고 오류 메시지를 출력하도록 조치
- measureperiod가 변경되면 rawperiod도 자동으로 갱신되도록 변경
- fft의 2차~10차 최대/최소 주파수 파라메터 삭제. 입력도 받지 않는다.
- setconnect 명령어에 따라 config->connect의 내용이 변경되는 경우 모든 AE의 config->connect의 내용이 동시에 변경되도록 수정. 이후 pm2 restart하여 새롭게 프로그램을 시작한다.

아직 setconnect는 제대로 된 테스트를 하지 못했기 때문에(서버 부재) setconnect 명령어를 보낼 때에는 주의해야 함